### PR TITLE
Repair FeignClient: Use feign dependencies for okhttp/httpclient

### DIFF
--- a/httpclient-spring-boot-sample/pom.xml
+++ b/httpclient-spring-boot-sample/pom.xml
@@ -28,23 +28,24 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+    
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-openfeign</artifactId>
     </dependency>
+     <!-- Add both clients to support this showcase -->
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-okhttp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-httpclient</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-    </dependency>
-
-    <!-- Add both clients to support this showcase -->
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Use `io.github.openfeign:feign-okhttp` and `io.github.openfeign:feign-httpclient instead` of `com.squareup.okhttp3:okhttp` and `org.apache.httpcomponents:httpclient`
If not, Feign client won't use these clients and won't honor the `feign.okhttp.enabled` / `feign.httpclient.enabled` configuration (and fallback to sun httpClient, without using the proxy selector)